### PR TITLE
Add per-image information

### DIFF
--- a/sources/meta-custom/classes/common-image-features.inc
+++ b/sources/meta-custom/classes/common-image-features.inc
@@ -1,4 +1,3 @@
-inherit recovery-image
 inherit set-root-pwd
 
 IMAGE_INSTALL += " \

--- a/sources/meta-custom/classes/custom-recovery-image.bbclass
+++ b/sources/meta-custom/classes/custom-recovery-image.bbclass
@@ -5,4 +5,5 @@ SUMMARY = "Customized recovery image / rootfs."
 
 LICENSE = "MIT"
 
+inherit recovery-image
 require common-image-features.inc

--- a/sources/meta-custom/classes/custom-system-image.bbclass
+++ b/sources/meta-custom/classes/custom-system-image.bbclass
@@ -5,4 +5,5 @@ SUMMARY = "Customized system image / rootfs."
 
 LICENSE = "MIT"
 
+inherit system-image
 require common-image-features.inc

--- a/sources/meta-multiboot-update/classes/minimal-image.bbclass
+++ b/sources/meta-multiboot-update/classes/minimal-image.bbclass
@@ -7,6 +7,9 @@ LICENSE = "MIT"
 
 inherit core-image
 
+# Include information about the build in the image
+inherit image-buildinfo
+
 IMAGE_INSTALL += " \
     bash \
     iproute2 \

--- a/sources/meta-multiboot-update/classes/recovery-image.bbclass
+++ b/sources/meta-multiboot-update/classes/recovery-image.bbclass
@@ -21,3 +21,14 @@ IMAGE_INSTALL += " \
 "
 
 IMAGE_FSTYPES = "${IMAGE_ROOTFS_FSTYPE} wic.bz2"
+
+# --------------
+# Postprocessing
+# --------------
+
+postprocess_recovery_image() {
+    # Mark the distro as recovery
+    sed -i 's/\b [0-9]\b/ (recovery)&/' ${IMAGE_ROOTFS}${sysconfdir}/issue
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "postprocess_recovery_image; "


### PR DESCRIPTION
To distinguish the mode the device is booted in, the `recovery` mode is now showing a corresponding note in the login screen (via `/etc/issue` file.

Additionally, build info is provided in the rootfs under `/etc/build`.