### PR TITLE
Fixed dependency in run-env to renamed submodule

### DIFF
--- a/config/bblayers.conf.sample
+++ b/config/bblayers.conf.sample
@@ -20,8 +20,8 @@ BBLAYERS = " \
   ##OEROOT##/../openembedded/meta-python \
   ##OEROOT##/../meta-rauc \
   ${BSP_LAYERS} \
+  ##OEROOT##/../meta-common-emx \
   ##OEROOT##/../meta-multiboot-update \
-  ##OEROOT##/../meta-common-configs \
   ##OEROOT##/../meta-custom \
 "
 

--- a/run-env.sh
+++ b/run-env.sh
@@ -82,8 +82,8 @@ export BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} \
   MMC_BLOCK_DEVICE \
 "
 
-# Extend whitelist with variables from meta-common-configs
+# Extend whitelist with variables from meta-common-emx
 # shellcheck disable=SC1091
-. ./sources/meta-common-configs/scripts/whitelisting.sh
+. ./sources/meta-common-emx/scripts/whitelisting.sh
 
 ./environment/init.sh --env-file "${SCRIPT_DIR}/.env" "${POSITIONAL_ARGS[@]}"


### PR DESCRIPTION
A missed reference to the renamed submodule led to failures in the build environment.