### PR TITLE
Setup  & adjust jenkins pipelines

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Embedded Linux Base Stack
 
-[![Build [raspberrypi]](https://ci.seydell.org/buildStatus/icon?job=EMX-BASE-STACK_dunfell_raspberrypi_Build&subject=raspberrypi3)](https://ci.seydell.org/job/EMX-BASE-STACK_dunfell_raspberrypi_Build/) 
+[![Build [kirkstone|raspberrypi]](https://ci.seydell.org/buildStatus/icon?job=emx-base-stack_kirkstone_raspberrypi3&subject=kirkstone/raspberrypi3)](https://ci.seydell.org/job/emx-base-stack_kirkstone_raspberrypi3/) [![Build [dunfell|raspberrypi]](https://ci.seydell.org/buildStatus/icon?job=emx-base-stack_dunfell_raspberrypi3&subject=dunfell/raspberrypi3)](https://ci.seydell.org/job/emx-base-stack_dunfell_raspberrypi3/) 
 
 This repository aims to provide a reference implementation for updateable, secure embedded Linux systems
 that are built with the Yocto build system.
@@ -78,10 +78,12 @@ For development, it is recommended to also install (and use!)
 ## Branching strategy
 
 The branches in this repo are aligned with the Yocto project releases.
-Currently supported releases:
 
-- _dunfell_
+Currently supported releases:
 - _kirkstone_
+
+Provided, yet not necessarily maintained releases:
+- _dunfell_ 
 
 Note: You have to checkout the corresponding branch as the build environment and features
 can significantly differ.

--- a/jenkins/Jenkinsfile_dunfell_raspberrypi3
+++ b/jenkins/Jenkinsfile_dunfell_raspberrypi3
@@ -1,17 +1,15 @@
 pipeline {
     agent any
-    
     parameters {
         choice(name: 'BuildArtifact', choices: ['full-image', 'system-update-bundle', 'recovery-update-bundle'], description: 'Select the build artefact to be created.')
         choice(name: 'Cache', choices: ['Wipe', 'Keep'], description: 'Select how the build cache should be handled. >Wipe< erases all cached data for all packages linked to the selected build target and >Keep< uses the cache as much as possible.')
+        booleanParam(name: 'RecreateEnvironment', defaultValue: false, description: 'Recreate the build environment?')
     }
     environment {
-        AGENT_DOCKER_VOLUME="jenkins_agent_workspace"
-        
         RELEASE_TAG="dunfell"
         ENV_FILE = """\
             USER=jenkins
-            MOUNT_VOLUME=${AGENT_DOCKER_VOLUME}:${WORKSPACE}/..
+            MOUNT_VOLUME=jenkins_agent_workspace:${WORKSPACE}/..
             PROJECT_ROOT=${WORKSPACE}
             POKY_DIR=sources/poky
             BUILD_DIR=build
@@ -36,22 +34,28 @@ pipeline {
                 ])
             }
         }
-        stage("Build [raspberrypi3]") {
+        stage('Prepare environment') {
             steps {
                 sh """
                     # Provide build environment
                     echo "${ENV_FILE}" > .env
-                    export RELEASE_TAG=${RELEASE_TAG}
+                    
+                    # Rebuild the environment itself
+                    if [ "${params.RecreateEnvironment}" = "true" ]; then
+                        ./run-env.sh --rebuild echo "Completed environment setup!"
+                    fi
                     
                     # Optionally clean the build cache
                     if [ "${params.Cache}" = "Wipe" ]; then
                         # Keep the sstatecache
                         rm -rf build/tmp
                     fi
-                    
-                    # Start build
-                    ./run-env.sh bitbake ${params.BuildArtifact}
                 """
+            }
+        }
+        stage("Build") {
+            steps {
+                sh "./run-env.sh bitbake ${params.BuildArtifact}"
             }
         }
     }

--- a/jenkins/Jenkinsfile_kirkstone_raspberrypi3
+++ b/jenkins/Jenkinsfile_kirkstone_raspberrypi3
@@ -1,0 +1,69 @@
+pipeline {
+    agent any
+    parameters {
+        choice(name: 'BuildArtifact', choices: ['full-image', 'system-update-bundle', 'recovery-update-bundle'], description: 'Select the build artefact to be created.')
+        choice(name: 'Cache', choices: ['Wipe', 'Keep'], description: 'Select how the build cache should be handled. >Wipe< erases all cached data for all packages linked to the selected build target and >Keep< uses the cache as much as possible.')
+        booleanParam(name: 'RecreateEnvironment', defaultValue: false, description: 'Recreate the build environment?')
+    }
+    environment {
+        RELEASE_TAG="kirkstone"
+        ENV_FILE = """\
+            USER=jenkins
+            MOUNT_VOLUME=jenkins_agent_workspace:${WORKSPACE}/..
+            PROJECT_ROOT=${WORKSPACE}
+            POKY_DIR=sources/poky
+            BUILD_DIR=build
+            PROJECT_TEMPLATE_DIR=config
+            MACHINE=raspberrypi3
+            BSP_LAYERS=${WORKSPACE}/sources/boards/raspberrypi/meta-raspberrypi,${WORKSPACE}/sources/boards/raspberrypi/meta-raspberrypi-multiboot-update
+            ROOT_PWD=super-secret-root-pwd
+            KEYBOARD_PROFILE=de-latin1.map
+            NETWORK_STATIC_IP=127.0.0.1
+            WIFI_SSID=Dummy-Network
+            WIFI_PWD=also-secret-network-pwd
+        """.stripIndent().stripMargin()
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "kirkstone"]],
+                    userRemoteConfigs: [[url: 'https://github.com/JSydll/emx-base-stack']],
+                    extensions: [[$class: 'SubmoduleOption', recursiveSubmodules: true]]
+                ])
+            }
+        }
+        stage('Prepare environment') {
+            steps {
+                sh """
+                    # Provide build environment
+                    echo "${ENV_FILE}" > .env
+                    
+                    # Rebuild the environment itself
+                    if [ "${params.RecreateEnvironment}" = "true" ]; then
+                        ./run-env.sh --rebuild echo "Completed environment setup!"
+                    fi
+                    
+                    # Optionally clean the build cache
+                    if [ "${params.Cache}" = "Wipe" ]; then
+                        # Keep the sstatecache
+                        rm -rf build/tmp
+                    fi
+                """
+            }
+        }
+        stage("Build") {
+            steps {
+                sh "./run-env.sh bitbake ${params.BuildArtifact}"
+            }
+        }
+    }
+    post {
+        success {
+            archiveArtifacts artifacts: 
+                "build/tmp/deploy/images/**/${params.BuildArtifact}-*.wic.bz, build/tmp/deploy/images/**/${params.BuildArtifact}-*.raucb",
+                    allowEmptyArchive: true, onlyIfSuccessful: true, followSymlinks: true
+        }
+    }
+}


### PR DESCRIPTION
Adds another pipeline for the kirkstone branch.

As making parts of the pipeline scripts reusable requires more effort than currently worth it (e.g. for creating a shared jenkins library), code duplication is accepted.