### PR TITLE
Minor size and boot speed improvements

### DIFF
--- a/sources/meta-multiboot-update/classes/partial-image.bbclass
+++ b/sources/meta-multiboot-update/classes/partial-image.bbclass
@@ -13,12 +13,8 @@ inherit image-buildinfo
 IMAGE_INSTALL += " \
     bash \
     iproute2 \
-    man \
     nano \
     rauc \
-    rsync \
-    screen \
-    sudo \
     \
     openssh \
     openssl \


### PR DESCRIPTION
As embedded devices are usually running headless, there's no need to wait on boot. Also, some non-required packages were removed.