### PR TITLE
[Fix] Add missing /boot mount again

### DIFF
--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/etc/fstab_common
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/etc/fstab_common
@@ -6,3 +6,4 @@
 
 # Setup persistent logging
 /var/persistent/private/log     /var/log    none    bind,x-systemd.requires=initialize-filesystem.service,defaults  0 0
+

--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init-config-mmc.inc
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init-config-mmc.inc
@@ -1,3 +1,8 @@
 inherit robust-filesystem-init-env
 
 FS_INIT_PERSISTENT_DEVICE = "/dev/${MMC_BLOCK_DEVICE}p${FS_PERSISTENT_PARTITION_OFFSET}"
+
+do_install:append() {
+    # Provide access to the bootloader environment on the boot partition
+    printf "/dev/${MMC_BLOCK_DEVICE}p1    /boot   vfat    defaults    0 0\n\n" >> ${D}/${sysconfdir}/fstab
+}

--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init-config-sda.inc
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init-config-sda.inc
@@ -1,3 +1,8 @@
 inherit robust-filesystem-init-env
 
 FS_INIT_PERSISTENT_DEVICE = "/dev/sda${FS_PERSISTENT_PARTITION_OFFSET}"
+
+do_install:append() {
+    # Provide access to the bootloader environment on the boot partition
+    printf "/dev/sda1    /boot   vfat    defaults    0 0\n\n" >> ${D}/${sysconfdir}/fstab
+}

--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init.inc
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/robust-filesystem-init.inc
@@ -7,8 +7,6 @@ SUMMARY = "Provides a failsafe filesystem initialization."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-require robust-filesystem-init-config-${STORAGE_TYPE}.inc
-
 inherit robust-filesystem-init-base
 
 # Note: The variable FS_INIT_PERSISTENT_DEVICE needs to be set via .bbappends or local.conf
@@ -35,6 +33,9 @@ RDEPENDS:${PN} += " \
 inherit systemd
 
 SYSTEMD_SERVICE:${PN} += "initialize-filesystem.service"
+
+# Storage type specific variable definitions and extensions
+require robust-filesystem-init-config-${STORAGE_TYPE}.inc
 
 do_install:append() {
     install -d ${D}/${bindir}


### PR DESCRIPTION
During the introduction of a robust filesystem setup, the `/boot` partition was removed from the `fstab` - but it is required to provide access to the bootloader environment.