### PR TITLE
[Fix] Overlay for /etc/ssh

### DIFF
--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/etc/fstab_common
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/etc/fstab_common
@@ -1,8 +1,8 @@
+# Share SSH configuration across the system
+etc_ssh_shared      /etc/ssh    overlay     lowerdir=/etc/ssh,upperdir=/var/persistent/shared/overlays/ssh,workdir=/var/persistent/shared/overlays/ssh-work,x-systemd.requires=initialize-filesystem.service,defaults  0 0
+
 # Provide access to shared media
 /var/persistent/shared/media    /media      none    bind,x-systemd.requires=initialize-filesystem.service,defaults  0 0
-
-# Share SSH configuration across the system
-/var/persistent/shared/ssh      /etc/ssh    none    bind,x-systemd.requires=initialize-filesystem.service,defaults  0 0
 
 # Setup persistent logging
 /var/persistent/private/log     /var/log    none    bind,x-systemd.requires=initialize-filesystem.service,defaults  0 0

--- a/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/usr/bin/initialize-filesystem.sh
+++ b/sources/meta-multiboot-update/recipes-platform/robust-filesystem-init/files/usr/bin/initialize-filesystem.sh
@@ -3,6 +3,7 @@
 # Sets up the required filesystem structure for overlays and shared data
 #
 
+mkdir -p /var/persistent/shared/overlays/ssh /var/persistent/shared/overlays/ssh-work
+
 mkdir -p /var/persistent/shared/media
-mkdir -p /var/persistent/shared/ssh
 mkdir -p /var/persistent/private/log


### PR DESCRIPTION
As there is relevant configuration data for `ssh` in the rootfs, an overlay must be used, not a bind mount.