### PR TITLE
Application dependency management improvements

### DIFF
--- a/sources/meta-custom/classes/custom-system-image.bbclass
+++ b/sources/meta-custom/classes/custom-system-image.bbclass
@@ -7,3 +7,7 @@ LICENSE = "MIT"
 
 inherit system-image
 require common-image-features.inc
+
+IMAGE_INSTALL += " \
+    sample-app \
+"

--- a/sources/meta-custom/recipes-application/sample-app/files/sample-app.service
+++ b/sources/meta-custom/recipes-application/sample-app/files/sample-app.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sample application
+Requires=regular-operation.target
+After=regular-operation.target
+
+[Service]
+Type=simple
+RemainAfterExit=yes
+ExecStart=/usr/bin/systemd-cat echo "Started Sample Application!"
+
+[Install]
+WantedBy=default.target

--- a/sources/meta-custom/recipes-application/sample-app/sample-app_1.0.bb
+++ b/sources/meta-custom/recipes-application/sample-app/sample-app_1.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Mimics a real-world application."
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+SRC_URI += " \
+    file://sample-app.service \
+"
+
+SYSTEMD_SERVICE:${PN} = " \
+    sample-app.service \
+"
+
+FILES:${PN} += "\
+    ${systemd_system_unitdir}/* \
+"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/sample-app.service ${D}${systemd_system_unitdir}/
+}

--- a/sources/meta-multiboot-update/classes/files/pre-init.j2
+++ b/sources/meta-multiboot-update/classes/files/pre-init.j2
@@ -3,12 +3,12 @@
 # Attempts to mount a persistent, writable partition to be used in overlays
 # and provides a volatile fallback in case of error
 
-function log() {
+function klog() {
     echo "<6>$1" > /dev/kmsg
 }
 
 function continue_init() {
-    log "Hand-over to original init routine..."
+    klog "Hand-over to original init routine..."
     exec /sbin/"{{ original_init_name }}"
 }
 
@@ -28,15 +28,15 @@ readonly VOLATILE_OVERLAYS_MOUNT_POINT="/var/volatile-overlays"
 readonly PRIVATE_DATA_DIR="/var/persistent/private"
 readonly SHARED_DATA_DIR="/var/persistent/shared"
 
-log "Starting pre-init routine..."
-log "Setup the volatile fallback fs..."
+klog "Starting pre-init routine..."
+klog "Setup the volatile fallback fs..."
 mount -t tmpfs -o defaults volatilefs "${VOLATILE_OVERLAYS_MOUNT_POINT}"
 
-log "Provide a writable, volatile /var/lib overlay..."
+klog "Provide a writable, volatile /var/lib overlay..."
 mkdir -p "${VOLATILE_OVERLAYS_MOUNT_POINT}"/var-lib "${VOLATILE_OVERLAYS_MOUNT_POINT}"/var-lib-work
 mount -t overlay -o defaults,lowerdir=/var/lib,upperdir="${VOLATILE_OVERLAYS_MOUNT_POINT}"/var-lib,workdir="${VOLATILE_OVERLAYS_MOUNT_POINT}"/var-lib-work overlay_var-lib /var/lib
 
-log "Provide a writable, volatile /etc overlay..."
+klog "Provide a writable, volatile /etc overlay..."
 
 # Note: While it would be more robust to only expose single files from /etc to be writable,
 # systemd does not yet fully support leaving /etc read-only and defining only certain
@@ -45,7 +45,7 @@ log "Provide a writable, volatile /etc overlay..."
 mkdir -p "${VOLATILE_OVERLAYS_MOUNT_POINT}"/etc "${VOLATILE_OVERLAYS_MOUNT_POINT}"/etc-work
 mount -t overlay -o defaults,lowerdir=/etc,upperdir="${VOLATILE_OVERLAYS_MOUNT_POINT}"/etc,workdir="${VOLATILE_OVERLAYS_MOUNT_POINT}"/etc-work overlay_etc /etc
 
-log "Mount the persistent filesystem and fallback to volatile on failure..."
+klog "Mount the persistent filesystem and fallback to volatile on failure..."
 if mount -t "${PARTITION_TYPE}" -o defaults,noatime "${PERSISTENT_DEVICE}" "${PERSISTENT_MOUNT_POINT}"; then
     PERSISTENT_DATA_DIR="${PERSISTENT_MOUNT_POINT}"
 else
@@ -56,4 +56,4 @@ mkdir -p "${PERSISTENT_DATA_DIR}/${SOFTWARE_MODE}" "${PERSISTENT_DATA_DIR}/share
 mount -o bind "${PERSISTENT_DATA_DIR}/${SOFTWARE_MODE}"  "${PRIVATE_DATA_DIR}"
 mount -o bind "${PERSISTENT_DATA_DIR}/shared"            "${SHARED_DATA_DIR}"
 
-log "Pre-init completed."
+klog "Pre-init completed."

--- a/sources/meta-multiboot-update/recipes-platform/update-observer/files/systemd/regular-operation.target
+++ b/sources/meta-multiboot-update/recipes-platform/update-observer/files/systemd/regular-operation.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=Indicates regular operation
+Wants=update-observer.service
+After=update-observer.service
+
+[Install]
+WantedBy=default.target
+

--- a/sources/meta-multiboot-update/recipes-platform/update-observer/files/systemd/update-observer.service
+++ b/sources/meta-multiboot-update/recipes-platform/update-observer/files/systemd/update-observer.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Initiates the software update.
+Requires=basic.target
+After=basic.target
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/sbin/update-observer
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/sources/meta-multiboot-update/recipes-platform/update-observer/update-observer_1.0.bb
+++ b/sources/meta-multiboot-update/recipes-platform/update-observer/update-observer_1.0.bb
@@ -12,22 +12,27 @@ inherit systemd
 SRC_URI += " \
     file://sbin/update-observer.sh \
     file://systemd/update-observer.service \
+    file://systemd/regular-operation.target \
 "
 
 RDEPENDS:${PN} = "bash inotify-tools sw-mode-control"
 
 SYSTEMD_SERVICE:${PN} = " \
     update-observer.service \
+    regular-operation.target \
 "
 
 FILES:${PN} += "\
     ${sbindir}/update-observer \
-    ${systemd_unitdir}/system/* \
+    ${systemd_system_unitdir}/* \
 "
 
 do_install() {
-    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${sbindir}
+    install -d ${D}${systemd_system_unitdir}
     
     install -D -m 0770 ${WORKDIR}/sbin/update-observer.sh ${D}${sbindir}/update-observer
-    install -m 0644 ${WORKDIR}/systemd/update-observer.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/systemd/update-observer.service ${D}${systemd_system_unitdir}
+
+    install -m 0644 ${WORKDIR}/systemd/regular-operation.target ${D}${systemd_system_unitdir}
 }


### PR DESCRIPTION
As a software update can significantly impact the system's IO usage, leading to application issues when having too less resources left, the applications should have the possibility to wait until the update finished.

For this purpose, a `regular-operation.target` systemd target is introduced that can be used by applications to depend their start on.