### PR TITLE
backend: Account for changes in upstream hawkbit repo.

### DIFF
--- a/backend/host-setup.sh
+++ b/backend/host-setup.sh
@@ -48,11 +48,6 @@ function checkout_latest_upstream() {
     fi
 }
 
-function patch_known_issues() {
-    # https://github.com/eclipse/hawkbit/issues/1366: Bump up the MySQL version to 8.0
-    sed -i 's|mysql:5.7|mysql:8.0|' "${HAWKBIT_SOURCE_DIR}/hawkbit-runtime/docker/docker-compose.yml"
-}
-
 function install_scripts() {
     cp -r "${SCRIPT_DIR}/run" "${INSTALL_DIR}"
 
@@ -96,8 +91,6 @@ install_required_packages
 
 echo "Checking out latest upstream sources in ${INSTALL_DIR}/hawkbit..."
 checkout_latest_upstream
-# This shall be removed as soon as upstream issues are resolved:
-patch_known_issues
 
 echo "Installing scripts..."
 install_scripts

--- a/backend/run/environment.sh
+++ b/backend/run/environment.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-readonly DOCKER_COMPOSE_PATH="%%HAWKBIT_REPO%%/hawkbit-runtime/docker/docker-compose.yml"
+readonly DOCKER_COMPOSE_PATH="%%HAWKBIT_REPO%%/hawkbit-runtime/docker/docker-compose-monolith-mysql-with-simple-ui.yml"


### PR DESCRIPTION
The `hawkbit` repo (or better the `docker` support in it) changed and the existing scripts needed to be fixed.

It could be a good idea to somehow decouple this for the future, though.